### PR TITLE
Changes/cleanups in preperation for N->M

### DIFF
--- a/jenkins/bme.functions.groovy
+++ b/jenkins/bme.functions.groovy
@@ -8,7 +8,6 @@ def get_deploy_node_ip() {
         String ip = (hosts=~ip_match)[0][1]
         return (ip)
     } else {
-
         return (null)
     }
 }
@@ -56,47 +55,351 @@ def get_controller_utility_container_ip(controller_name='controller01') {
     return (container_ip)
 }
 
-def get_tempest_dir(controller_name='controller01') {
-  String host_ip = get_deploy_node_ip()
-  String container_ip = get_controller_utility_container_ip(controller_name)
-  String tempest_dir = ""
-  try {
-      tempest_dir = sh returnStdout: true, script: """
-          ssh -o StrictHostKeyChecking=no\
-          -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${container_ip} '''
-              TEMPEST_DIR=\$(find / -maxdepth 4 -type d -name "tempest*untagged" | head -1)
-              echo \$TEMPEST_DIR
-          '''
-      """
-  } catch(err) {
-      echo "Error in determining Tempest location"
-      throw err
-  }
-  return (tempest_dir)
+def run_tempest_tests(controller_name='controller01', regex='smoke', results_file = null, elasticsearch_ip = null){
+    String host_ip = get_deploy_node_ip()
+
+    def failures
+
+    tempest_output = sh returnStdout: true, script: """
+        ssh -o StrictHostKeyChecking=no\
+        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
+            cd /root/tempest
+            stream_id=\$(cat .testrepository/next-stream)
+            ostestr --regex ${regex} || echo 'Some smoke tests failed.'
+            mkdir -p subunit/smoke || echo "smoke subunit directory exists"
+            cp .testrepository/\$stream_id subunit/smoke/${results_file}
+        '''
+    """
+    if (tempest_output.contains('- Failed:') == true) {
+        failures = tempest_output.substring(tempest_output.indexOf('- Failed:') + 10)
+        failures = failures.substring(0,failures.indexOf('\n')).toInteger()
+        echo failures + ' failures in Tempest smoke tests'
+    } else {
+        echo "Tempest tests succeeded"
+    }
+    echo tempest_output
 }
 
-def configure_tempest(controller_name='controller01', tempest_dir=null){
+def install_persistent_resources_tests(controller_name='controller01') {
     String host_ip = get_deploy_node_ip()
-    String container_ip = get_controller_utility_container_ip(controller_name)
+
+    // Install Persistent Resources tests on the utility container on ${controller}
+    echo 'Installing Persistent Resources Tempest Plugin on ' + controller_name
+    sh """
+        ssh -o StrictHostKeyChecking=no\
+        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
+            cd /root/tempest
+            if [[ -d persistent-resources-tests ]]; then
+                cd persistent-resources-tests
+                git pull
+            else
+                git clone https://github.com/osic/persistent-resources-tests.git
+                cd persistent-resources-tests
+            fi
+            pip install --upgrade .
+        '''
+    """
+}
+
+def install_persistent_resources_tests_parse(controller_name='controller01') {
+    String host_ip = get_deploy_node_ip()
+    // Install Persistent Resources tests parse on the controller node ${controller_name}
+    echo 'Installing Persistent Resources Tempest Plugin'
+    sh """
+        ssh -o StrictHostKeyChecking=no\
+        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
+            cd /root/tempest
+            if [[ -d persistent-resources-tests-parse ]]; then
+                cd persistent-resources-tests-parse
+                git pull
+            else
+                git clone https://github.com/osic/persistent-resources-tests-parse.git
+                cd persistent-resources-tests-parse
+            fi
+            pip install --upgrade .
+        '''
+    """
+}
+
+def run_persistent_resources_tests(controller_name='controller01', action='verify', results_file=null){
+    String host_ip = get_deploy_node_ip()
+
+    if (results_file == null) {
+        results_file = action
+    }
 
     sh """
         ssh -o StrictHostKeyChecking=no\
-        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${container_ip} '''
-            TEMPEST_DIR=${tempest_dir}
-            cd \$TEMPEST_DIR
-            # Make sure tempest is installed
-            pip install .
+        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
+            cd /root/tempest
+            stream_id=\$(cat .testrepository/next-stream)
+            ostestr --regex persistent-${action} || echo 'Some persistent resources tests failed.'
+            mkdir -p subunit/persistent_resources/
+            cp .testrepository/\$stream_id subunit/persistent_resources/${results_file}
+        '''
+    """
+}
+
+def parse_persistent_resources_tests(controller_name='controller01'){
+    String host_ip = get_deploy_node_ip()
+
+    sh """
+        ssh -o StrictHostKeyChecking=no\
+        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
+            cd /root/tempest/subunit/persistent_resources/
+            mkdir /root/tempest/output || echo "output directory exists"
+            resource-parse --u . > /root/tempest/output/persistent_resource.txt
+            rm *.csv
+        '''
+    """
+}
+
+def install_rally(controller_name='controller01') {
+    String host_ip = get_deploy_node_ip()
+
+    echo 'Installing rally on ${controller_name}'
+    sh """
+        ssh -o StrictHostKeyChecking=no\
+        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
+            rm -rf rally.git/ || echo "rally directory does not exist"
+            apt-get install -y libpq-dev libxml2-dev libxslt1-dev
+            wget -q -O- https://raw.githubusercontent.com/openstack/rally/master/install_rally.sh | bash
+            cd rally.git/
+            git clone https://github.com/osic/rally-scenarios.git
+            cd rally-scenarios/
+            python extract_values.py
+        '''
+    """
+}
+
+def prime_rally_benchmarks(controller_name='controller01') {
+    String host_ip = get_deploy_node_ip()
+
+    echo 'Priming rally benchmarks on ${controller_name}'
+    sh """
+        ssh -o StrictHostKeyChecking=no\
+        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
+            cd /root/
+            source openrc
+            rally-manage db recreate
+            rally deployment create --fromenv --name=existing
+            rally deployment use --deployment existing
+            cd rally.git/rally-scenarios/
+            rally task start osic-keystone-prime-scenario.json --task-args-file args.yaml
+            rally task start osic-nova-1-server-scenario.json --task-args-file args.yaml
+        '''
+    """
+}
+
+def run_rally_benchmarks(controller_name='controller01', results_file = 'results') {
+    String host_ip = get_deploy_node_ip()
+
+    echo 'Running rally benchmarks on ${controller_name}'
+    sh """
+        ssh -o StrictHostKeyChecking=no\
+        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
+            cd /root/
+            source openrc
+            rally deployment use --deployment existing
+            cd rally.git/rally-scenarios/
+            rally task start benchmark.json --task-args-file args.yaml
+            rally task results > /root/output/${results_file}.json
+        '''
+    """
+}
+
+def transfer_tempest_configuration_to_controller(controller_name='controller01'){
+    String container_ip = get_controller_utility_container_ip(controller_name)
+    String host_ip = get_deploy_node_ip()
+
+    try {
+        sh """
+            scp -o StrictHostKeyChecking=no\
+            -o ProxyCommand='ssh -W %h:%p root@${host_ip}'\
+            -r root@${container_ip}:/opt/tempest_untagged/etc .
+
+            scp -o StrictHostKeyChecking=no\
+            -o ProxyCommand='ssh -W %h:%p root@${host_ip}'\
+            -r root@${container_ip}:/root/openrc .
+
+            scp -o StrictHostKeyChecking=no\
+            -o ProxyCommand='ssh -W %h:%p root@${host_ip}'\
+            -r etc root@${controller_name}:/root/
+
+            rm -rf etc
+
+            scp -o StrictHostKeyChecking=no\
+            -o ProxyCommand='ssh -W %h:%p root@${host_ip}'\
+            -r openrc root@${controller_name}:/root/
+
+            rm -f openrc
+        """
+    } catch(err) {
+        echo "Error moving tempest etc directory"
+        echo err.message
+    }
+}
+
+def install_during_upgrade_tests(controller_name='controller01') {
+    String host_ip = get_deploy_node_ip()
+    // Install during upgrade tests on ${controller}
+    echo 'Installing during upgrade test on ${controller}_utility container'
+    sh """
+        ssh -o StrictHostKeyChecking=no\
+        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
+            cd /root/
+            mkdir -p /root/output || echo "output directory exists"
+            rm -rf rolling-upgrades-during-test
+            git clone https://github.com/osic/rolling-upgrades-during-test
+            cd rolling-upgrades-during-test
+            pip install -r requirements.txt
+        '''
+    """
+}
+
+def start_during_upgrade_test(controller_name='controller01') {
+    String host_ip = get_deploy_node_ip()
+    // Start during upgrade tests ${controller}
+    sh """
+        ssh -o StrictHostKeyChecking=no\
+        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
+            set -x
+            cd /root/rolling-upgrades-during-test
+            python call_test.py --daemon -s swift,keystone --output-file /root/output/during.uptime.out > /root/output/during_log_1
+        ''' &
+    """
+}
+
+def start_nova_during_upgrade_test(controller_name='controller01') {
+    String host_ip = get_deploy_node_ip()
+    // Start during upgrade tests on the utility container on ${controller}
+    sh """
+        ssh -o StrictHostKeyChecking=no\
+        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
+            set -x
+            cd /root/rolling-upgrades-during-test
+            python call_test.py --daemon -m -s nova --output-file /root/output/during.novauptime.out > /root/output/during_log_2
+        ''' &
+    """
+}
+
+def stop_during_upgrade_test(controller_name='controller01') {
+    String host_ip = get_deploy_node_ip()
+    // Stop during upgrade tests on ${controller}
+    sh """
+        ssh -o StrictHostKeyChecking=no\
+        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
+            touch /usr/during.uptime.stop
+            ps aux|grep call_test > /root/output/after_stopdur_processes.txt
+        '''
+    """
+}
+
+def install_api_uptime_tests(controller_name='controller01') {
+    String host_ip = get_deploy_node_ip()
+    // install api uptime tests on ${controller}
+    sh """
+        ssh -o StrictHostKeyChecking=no\
+        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
+            mkdir -p /root/output || echo "output directory exists"
+            rm -rf /root/api_uptime
+            git clone https://github.com/osic/api_uptime.git /root/api_uptime
+            cd /root/api_uptime
+            pip install --upgrade -r requirements.txt
+        '''
+    """
+}
+
+def start_api_uptime_tests(controller_name='controller01') {
+    String host_ip = get_deploy_node_ip()
+    // start api uptime tests on ${controller}
+    sh """
+        ssh -o StrictHostKeyChecking=no\
+        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
+            set -x
+            rm -f /usr/api.uptime.stop
+            cd /root/api_uptime/api_uptime
+            python call_test.py --daemon --output-file /root/output/api.uptime.out
+        ''' &
+    """
+}
+
+def stop_api_uptime_tests(controller_name='controller01') {
+    String host_ip = get_deploy_node_ip()
+    // Stop api uptime tests on ${controller}
+    sh """
+        ssh -o StrictHostKeyChecking=no\
+        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
+            set -x
+            ps aux|grep call_test > /root/output/processes.txt
+            touch /usr/api.uptime.stop
+            ps aux|grep call_test > /root/output/after_stopapi_processes.txt
+
+            # Wait up to 60 seconds for the results file gets created by the script
+            x=0
+            while [ \$x -lt 600 -a ! -e /root/output/api.uptime.out ]; do
+                x=\$((x+1))
+                sleep .1
+            done
+        '''
+    """
+}
+
+def install_tempest_tests(controller_name='controller01') {
+    String host_ip = get_deploy_node_ip()
+    String container_ip = get_controller_utility_container_ip(controller_name)
+
+    // install tempest via playbook to generate configuration
+    sh """
+        ssh -o StrictHostKeyChecking=no root@${host_ip} '''
+        cd /opt/openstack-ansible/playbooks
+        openstack-ansible os-tempest-install.yml
+        '''
+    """
+
+    // install tempest master on controller node
+    sh """
+        ssh -o StrictHostKeyChecking=no\
+        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
+            # install tempest master
+            cd /root/
+            if [[ -d tempest ]]; then
+                cd tempest/
+                git pull
+            else
+                git clone https://github.com/openstack/tempest
+                cd tempest/
+            fi
+            pip install --upgrade .
             testr init || echo "already configured"
             mkdir subunit || echo "subunit directory exists"
         '''
     """
 
-    results = sh returnStdout: true, script: """
+    // get generated configuration
+    try {
+       sh """
+          scp -o StrictHostKeyChecking=no\
+          -o ProxyCommand='ssh -W %h:%p root@${host_ip}'\
+           root@${container_ip}:/openstack/venvs/tempest-untagged/etc/tempest.conf .
+
+          scp -o StrictHostKeyChecking=no\
+          -o ProxyCommand='ssh -W %h:%p root@${host_ip}'\
+           tempest.conf root@${controller_name}:/root/tempest/etc/
+
+          rm -f tempest.conf
+       """
+    } catch(err) {
+        echo "Error moving tempest configuration"
+        echo err.message
+    }
+
+    // update configuration using template from github and generated results from playbook
+    sh """
         ssh -o StrictHostKeyChecking=no\
-        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${container_ip} '''
-            # Make sure etc/tempest.conf exists
-            TEMPEST_DIR=${tempest_dir}
-            cd \$TEMPEST_DIR
+        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
+            set -x
+            cd /root/tempest
             if [[ -f etc/tempest.conf ]]; then
                 mv etc/tempest.conf etc/tempest.conf.orig
                 wget https://raw.githubusercontent.com/osic/qe-jenkins-baremetal/master/jenkins/tempest.conf -O etc/tempest.conf
@@ -119,373 +422,14 @@ def configure_tempest(controller_name='controller01', tempest_dir=null){
             fi
         '''
     """
-    if (results == "No existing tempest.conf"){
-        echo "No existing tempest.conf"
-    }
 }
 
-def run_tempest_tests(controller_name='controller01', regex='smoke', results_file = null, elasticsearch_ip = null, tempest_dir=null){
-    String host_ip = get_deploy_node_ip()
-    String container_ip = get_controller_utility_container_ip(controller_name)
-
-    def failures
-
-    tempest_output = sh returnStdout: true, script: """
-        ssh -o StrictHostKeyChecking=no\
-        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${container_ip} '''
-            TEMPEST_DIR=${tempest_dir}
-            cd \$TEMPEST_DIR
-            stream_id=\$(cat .testrepository/next-stream)
-            ostestr --regex ${regex} || echo 'Some smoke tests failed.'
-            mkdir -p /opt/tempest_untagged/subunit/smoke
-            cp .testrepository/\$stream_id /opt/tempest_untagged/subunit/smoke/${results_file}
-        '''
-    """
-    if (tempest_output.contains('- Failed:') == true) {
-        failures = tempest_output.substring(tempest_output.indexOf('- Failed:') + 10)
-        failures = failures.substring(0,failures.indexOf('\n')).toInteger()
-        if (failures >= 0) {
-            echo 'Parsing failed smoke'
-            echo 'Failures'
-            echo tempest_output
-            try {
-                //Let's leave this out for now since we aren't actually stopping the tests on fails.
-                //aggregate_parse_failed_smoke(host_ip, results_file, elasticsearch_ip, controller_name, tempest_dir)
-            } catch (err){
-                echo "error parsing failed smoke"
-                echo err.message
-            }
-                //if (elasticsearch_ip != null) {
-                //
-                //}
-            //error "${failures} tests from the Tempest smoke tests failed, stopping the pipeline."
-        } else {
-            echo 'The Tempest smoke tests were successfull.'
-        }
-    } else {
-        error 'There was an error running the smoke tests, stopping the pipeline.'
-    }
-}
-
-def install_persistent_resources_tests(controller_name='controller01', tempest_dir=null) {
-    String host_ip = get_deploy_node_ip()
-    String container_ip = get_controller_utility_container_ip(controller_name)
-    // Install Persistent Resources tests on the utility container on ${controller}
-    echo 'Installing Persistent Resources Tempest Plugin on the onMetal host'
-    sh """
-        ssh -o StrictHostKeyChecking=no\
-        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${container_ip} '''
-            TEMPEST_DIR=${tempest_dir}
-            #rm -rf \$TEMPEST_DIR/persistent-resources-tests
-            git clone https://github.com/osic/persistent-resources-tests.git \$TEMPEST_DIR/persistent-resources-tests || echo "dir exists"
-            pip install --upgrade \$TEMPEST_DIR/persistent-resources-tests/
-        '''
-    """
-}
-
-def install_persistent_resources_tests_parse(controller_name='controller01', tempest_dir=null) {
-    String host_ip = get_deploy_node_ip()
-    String container_ip = get_controller_utility_container_ip(controller_name)
-    // Install Persistent Resources tests parse on the utility container on ${controller}
-    echo 'Installing Persistent Resources Tempest Plugin'
-    sh """
-        ssh -o StrictHostKeyChecking=no\
-        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${container_ip} '''
-            TEMPEST_DIR=${tempest_dir}
-            rm -rf \$TEMPEST_DIR/persistent-resources-tests-parse
-            git clone https://github.com/osic/persistent-resources-tests-parse.git \$TEMPEST_DIR/persistent-resources-tests-parse
-            pip install --upgrade \$TEMPEST_DIR/persistent-resources-tests-parse/
-        '''
-    """
-}
-
-def run_persistent_resources_tests(controller_name='controller01', action='verify', results_file=null, tempest_dir=null){
-    String host_ip = get_deploy_node_ip()
-    String container_ip = get_controller_utility_container_ip(controller_name)
-
-    if (results_file == null) {
-        results_file = action
-    }
-
-    sh """
-        ssh -o StrictHostKeyChecking=no\
-        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${container_ip} '''
-            TEMPEST_DIR=${tempest_dir}
-            cd \$TEMPEST_DIR
-            stream_id=\$(cat .testrepository/next-stream)
-            ostestr --regex persistent-${action} || echo 'Some persistent resources tests failed.'
-            mkdir -p /opt/tempest_untagged/subunit/persistent_resources/
-            #cp .testrepository/\$stream_id \$TEMPEST_DIR/subunit/persistent_resources/${results_file}
-            cp .testrepository/\$stream_id /opt/tempest_untagged/subunit/persistent_resources/${results_file}
-        '''
-    """
-}
-
-def parse_persistent_resources_tests(controller_name='controller01', tempest_dir=null){
-    String host_ip = get_deploy_node_ip()
-    String container_ip = get_controller_utility_container_ip(controller_name)
-
-    sh """
-        ssh -o StrictHostKeyChecking=no\
-        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${container_ip} '''
-            TEMPEST_DIR=${tempest_dir}
-            cd \$TEMPEST_DIR/subunit/persistent_resources/
-            mkdir /opt/tempest_untagged/output || echo "output directory exists"
-            #resource-parse --u . > \$TEMPEST_DIR/output/persistent_resource.txt
-            resource-parse --u . > /opt/tempest_untagged/output/persistent_resource.txt
-            rm *.csv
-        '''
-    """
-}
-
-/*def copy_tempest_configuration_for_rally(controller_name='controller01'){
-  String container_ip = get_controller_utility_container_ip(controller_name)
-  String host_ip = get_deploy_node_ip()
-
-  try {
-      sh """
-
-          ssh -o StrictHostKeyChecking=no\
-          -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${container_ip} '''
-
-             scp -o StrictHostKeyChecking=no\
-             -o ProxyCommand='ssh -W %h:%p root@${container_ip}:/opt/tempest_untagged/etc/tempest.conf \
-             root@${host_ip}:/root/
-
-             scp -o StrictHostKeyChecking=no\
-             -o ProxyCommand='ssh -W %h:%p root@${container_ip}:/root/openrc \
-             root@${host_ip}:/root/
-          '''
-
-          scp -o StrictHostKeyChecking=no\
-          -o ProxyCommand='ssh -W %h:%p root@${host_ip}:/root/openrc \
-          /root/tempest.conf root@${controller_name}:/root/
-
-          scp -o StrictHostKeyChecking=no\
-          -o ProxyCommand='ssh -W %h:%p root@${host_ip}:/root/tempest.conf \
-          /root/openrc root@${controller_name}:/root/
-      """
-  } catch(err) {
-      echo "Error moving tempest config and openrc directory"
-      echo err.message
-  }
-}*/
-
-def install_rally(controller_name='controller01', tempest_dir=null) {
-    String host_ip = get_deploy_node_ip()
-
-    echo 'Installing rally on ${controller_name}'
-    sh """
-        ssh -o StrictHostKeyChecking=no\
-        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
-            rm -rf rally.git/ || echo "rally directory does not exist"
-            apt-get install -y libpq-dev libxml2-dev libxslt1-dev
-            wget -q -O- https://raw.githubusercontent.com/openstack/rally/master/install_rally.sh | bash
-            cd rally.git/
-            git clone https://github.com/osic/rally-scenarios.git
-            cd rally-scenarios/
-            python extract_values.py
-        '''
-    """
-}
-
-def prime_rally_benchmarks(controller_name='controller01', tempest_dir=null) {
-    String host_ip = get_deploy_node_ip()
-
-    echo 'Priming rally benchmarks on ${controller_name}'
-    sh """
-        ssh -o StrictHostKeyChecking=no\
-        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
-            cd /root/
-            source openrc
-            rally-manage db recreate
-            rally deployment create --fromenv --name=existing
-            rally deployment use --deployment existing
-            cd rally.git/rally-scenarios/
-            rally task start osic-keystone-prime-scenario.json --task-args-file args.yaml
-            rally task start osic-nova-1-server-scenario.json --task-args-file args.yaml
-        '''
-    """
-}
-
-def run_rally_benchmarks(controller_name='controller01', tempest_dir=null, results_file = 'results') {
-    String host_ip = get_deploy_node_ip()
-//    String container_ip = get_controller_utility_container_ip(controller_name)
-
-    echo 'Running rally benchmarks on ${controller_name}'
-    sh """
-        ssh -o StrictHostKeyChecking=no\
-        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
-            cd /root/
-            source openrc
-            rally deployment use --deployment existing
-            cd rally.git/rally-scenarios/
-            rally task start benchmark.json --task-args-file args.yaml
-            rally task results > /root/output/${results_file}.json
-        '''
-    """
-}
-
-def transfer_tempest_configuration_to_controller(controller_name='controller01'){
-  String container_ip = get_controller_utility_container_ip(controller_name)
-  String host_ip = get_deploy_node_ip()
-
-  try {
-      sh """
-          scp -o StrictHostKeyChecking=no\
-          -o ProxyCommand='ssh -W %h:%p root@${host_ip}'\
-          -r root@${container_ip}:/opt/tempest_untagged/etc .
-
-          scp -o StrictHostKeyChecking=no\
-          -o ProxyCommand='ssh -W %h:%p root@${host_ip}'\
-          -r root@${container_ip}:/root/openrc .
-
-          scp -o StrictHostKeyChecking=no\
-          -o ProxyCommand='ssh -W %h:%p root@${host_ip}'\
-          -r etc root@${controller_name}:/root/
-
-          scp -o StrictHostKeyChecking=no\
-          -o ProxyCommand='ssh -W %h:%p root@${host_ip}'\
-          -r openrc root@${controller_name}:/root/
-      """
-  } catch(err) {
-      echo "Error moving tempest etc directory"
-      echo err.message
-  }
-}
-
-def install_during_upgrade_tests(controller_name='controller01', tempest_dir=null) {
-    String host_ip = get_deploy_node_ip()
-    //String container_ip = get_controller_utility_container_ip(controller_name)
-    // Install during upgrade tests on the utility container on ${controller}
-    echo 'Installing during upgrade test on ${controller}_utility container'
-    sh """
-        ssh -o StrictHostKeyChecking=no\
-        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
-            cd /root/
-            mkdir -p /root/output || echo "output directory exists"
-            rm -rf rolling-upgrades-during-test
-            git clone https://github.com/osic/rolling-upgrades-during-test
-            cd rolling-upgrades-during-test
-            pip install -r requirements.txt
-        '''
-    """
-}
-
-def start_during_upgrade_test(controller_name='controller01', tempest_dir=null) {
-    String host_ip = get_deploy_node_ip()
-    //String container_ip = get_controller_utility_container_ip(controller_name)
-    // Start during upgrade tests on the utility container on ${controller}
-    sh """
-        ssh -o StrictHostKeyChecking=no\
-        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
-            set -x
-            cd /root/rolling-upgrades-during-test
-            python call_test.py --daemon -s swift,keystone --output-file /root/output/during.uptime.out > /root/output/during_log_1
-        ''' &
-    """
-}
-
-def start_nova_during_upgrade_test(controller_name='controller01', tempest_dir=null) {
-    String host_ip = get_deploy_node_ip()
-    //String container_ip = get_controller_utility_container_ip(controller_name)
-    // Start during upgrade tests on the utility container on ${controller}
-    sh """
-        ssh -o StrictHostKeyChecking=no\
-        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
-            set -x
-            cd /root/rolling-upgrades-during-test
-            python call_test.py --daemon -m -s nova --output-file /root/output/during.novauptime.out > /root/output/during_log_2
-        ''' &
-    """
-}
-
-def stop_during_upgrade_test(controller_name='controller01', tempest_dir=null) {
-    String host_ip = get_deploy_node_ip()
-    // String container_ip = get_controller_utility_container_ip(controller_name)
-    // Stop during upgrade tests on the utility container on ${controller}
-    sh """
-        ssh -o StrictHostKeyChecking=no\
-        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
-            touch /usr/during.uptime.stop
-            ps aux|grep call_test > /root/output/after_stopdur_processes.txt
-        '''
-    """
-}
-
-def install_api_uptime_tests(controller_name='controller01', tempest_dir=null) {
-    String host_ip = get_deploy_node_ip()
-    //String container_ip = get_controller_utility_container_ip(controller_name)
-    // install api uptime tests on utility container on ${controller}
-    sh """
-        ssh -o StrictHostKeyChecking=no\
-        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
-            mkdir -p /root/output || echo "output directory exists"
-            rm -rf /root/api_uptime
-            git clone https://github.com/osic/api_uptime.git /root/api_uptime
-            cd /root/api_uptime
-            pip install --upgrade -r requirements.txt
-        '''
-    """
-}
-
-def start_api_uptime_tests(controller_name='controller01', tempest_dir=null) {
-    String host_ip = get_deploy_node_ip()
-    String container_ip = get_controller_utility_container_ip(controller_name)
-    // start api uptime tests on the utility container on ${controller}
-    sh """
-        ssh -o StrictHostKeyChecking=no\
-        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
-            set -x
-            rm -f /usr/api.uptime.stop
-            cd /root/api_uptime/api_uptime
-            python call_test.py --daemon --output-file /root/output/api.uptime.out
-        ''' &
-    """
-}
-
-def stop_api_uptime_tests(controller_name='controller01', tempest_dir=null) {
-    String host_ip = get_deploy_node_ip()
-    // String container_ip = get_controller_utility_container_ip(controller_name)
-    // Stop api uptime tests on the utility container on ${controller}
-    sh """
-        ssh -o StrictHostKeyChecking=no\
-        -o ProxyCommand='ssh -W %h:%p root@${host_ip}' root@${controller_name} '''
-            set -x
-            ps aux|grep call_test > /root/output/processes.txt
-            touch /usr/api.uptime.stop
-            ps aux|grep call_test > /root/output/after_stopapi_processes.txt
-
-            # Wait up to 60 seconds for the results file gets created by the script
-            x=0
-            while [ \$x -lt 600 -a ! -e /root/output/api.uptime.out ]; do
-                x=\$((x+1))
-                sleep .1
-            done
-        '''
-    """
-}
-
-def install_tempest_tests(controller_name='controller01') {
-    String host_ip = get_deploy_node_ip()
-
-    sh """
-        ssh -o StrictHostKeyChecking=no root@${host_ip} '''
-        cd /opt/openstack-ansible/playbooks
-        openstack-ansible os-tempest-install.yml
-        '''
-    """
-}
-
-def aggregate_parse_failed_smoke(host_ip, results_file, elasticsearch_ip, controller_name='controller01', tempest_dir=null) {
-    String container_ip = get_controller_utility_container_ip(controller_name)
-
+def aggregate_parse_failed_smoke(host_ip, results_file, elasticsearch_ip, controller_name='controller01') {
     try {
         sh """
-            TEMPEST_DIR=${tempest_dir}
             scp -o StrictHostKeyChecking=no\
             -o ProxyCommand='ssh -W %h:%p root@${host_ip}'\
-            -r root@${container_ip}:\$TEMPEST_DIR/output .
+            -r root@${controller_name}:/root/tempest/output .
 
             scp -o StrictHostKeyChecking=no\
             -r output ubuntu@${elasticsearch_ip}:/home/ubuntu/
@@ -497,10 +441,9 @@ def aggregate_parse_failed_smoke(host_ip, results_file, elasticsearch_ip, contro
 
     try {
         sh """
-            TEMPEST_DIR=${tempest_dir}
             scp -o StrictHostKeyChecking=no\
             -o ProxyCommand='ssh -W %h:%p root@${host_ip}'\
-            -r root@${container_ip}:\$TEMPEST_DIR/subunit .
+            -r root@${controller_name}:/root/tempest/subunit .
 
             scp -o StrictHostKeyChecking=no\
             -r subunit ubuntu@${elasticsearch_ip}:/home/ubuntu/
@@ -531,18 +474,18 @@ def aggregate_parse_failed_smoke(host_ip, results_file, elasticsearch_ip, contro
 }
 
 def cleanup_test_results() {
-  // Clean up existing tests results on elasticsearch node
-  try {
-      sh """
-          rm -rf /home/ubuntu/output || echo "no output directory exists"
-          rm -rf /home/ubuntu/subunit || echo "no subunit directory exists"
-          rm -rf /home/ubuntu/uptime_output || echo "no subunit directory exists"
-      """
-      echo "Previous test runs removed"
-  } catch(err) {
-     echo "Error removing previous test runs"
-     echo err.message
-  }
+    // Clean up existing tests results on elasticsearch node
+    try {
+        sh """
+            rm -rf /home/ubuntu/output || echo "no output directory exists"
+            rm -rf /home/ubuntu/subunit || echo "no subunit directory exists"
+            rm -rf /home/ubuntu/uptime_output || echo "no subunit directory exists"
+        """
+        echo "Previous test runs removed"
+    } catch(err) {
+      echo "Error removing previous test runs"
+      echo err.message
+    }
 }
 
 def connect_vpn(host=null, user=null, pass=null){
@@ -551,53 +494,53 @@ def connect_vpn(host=null, user=null, pass=null){
         error 'Missing required parameter'
     }
     sh """
-    set -x
-    alias f5fpc="/usr/local/bin/f5fpc"
-    function vpn_info() { f5fpc --info | grep -q "Connection Status"; echo \$?; }
-    if [[ \$(vpn_info) -eq 0 ]]; then
-        echo "VPN connection already established"
-    else
-      f5fpc --start --host https://${host}\
-         --user ${user} --password ${pass} --nocheck &
-      test_vpn=0
-      while [[ \$(vpn_info) -ne 0 ]]; do
-        # wait for vpn, up to 20 seconds
-        if [[ \${test_vpn} -gt 20 ]]; then
-          echo "Could not establish VPN"
-          exit 2
+        set -x
+        alias f5fpc="/usr/local/bin/f5fpc"
+        function vpn_info() { f5fpc --info | grep -q "Connection Status"; echo \$?; }
+        if [[ \$(vpn_info) -eq 0 ]]; then
+            echo "VPN connection already established"
+        else
+            f5fpc --start --host https://${host}\
+            --user ${user} --password ${pass} --nocheck &
+            test_vpn=0
+            while [[ \$(vpn_info) -ne 0 ]]; do
+                # wait for vpn, up to 20 seconds
+                if [[ \${test_vpn} -gt 20 ]]; then
+                    echo "Could not establish VPN"
+                    exit 2
+                fi
+                test_vpn=\$(expr \$test_vpn + 1)
+                sleep 1
+            done
+            # adding a sleep to let the connection complete
+            sleep 5
+            echo "VPN established"
         fi
-        test_vpn=\$(expr \$test_vpn + 1)
-        sleep 1
-      done
-      # adding a sleep to let the connection complete
-      sleep 5
-      echo "VPN established"
-    fi
     """
 }
 
 def disconnect_vpn(){
     sh """
-  set -x
-  alias f5fpc="/usr/local/bin/f5fpc"
-  function vpn_info() { f5fpc --info | grep -q "Connection Status"; echo \$?; }
-  if [[ \$(vpn_info) -eq 1 ]]; then
-      echo "VPN not connected"
-  else
-    f5fpc --stop &
-    test_vpn=0
-    while [[ \$(vpn_info) -ne 1 ]]; do
-      # wait for vpn, up to 20 seconds
-      if [[ \${test_vpn} -gt 20 ]]; then
-        echo "Error disconnecting VPN"
-        exit 2
-      fi
-      test_vpn=\$(expr \$test_vpn + 1)
-      sleep 1
-    done
-    echo "VPN disconnected"
-  fi
-  """
+        set -x
+        alias f5fpc="/usr/local/bin/f5fpc"
+        function vpn_info() { f5fpc --info | grep -q "Connection Status"; echo \$?; }
+        if [[ \$(vpn_info) -eq 1 ]]; then
+            echo "VPN not connected"
+        else
+            f5fpc --stop &
+            test_vpn=0
+            while [[ \$(vpn_info) -ne 1 ]]; do
+                # wait for vpn, up to 20 seconds
+                if [[ \${test_vpn} -gt 20 ]]; then
+                    echo "Error disconnecting VPN"
+                    exit 2
+                fi
+                test_vpn=\$(expr \$test_vpn + 1)
+                sleep 1
+            done
+            echo "VPN disconnected"
+        fi
+    """
 }
 
 def rebuild_environment() {
@@ -611,24 +554,27 @@ def rebuild_environment() {
     """
 }
 
-def bash_upgrade_openstack(release='master', retries=2, fake_results=false) {
+def bash_upgrade_openstack(release='master', retries=2) {
     // ***Requires Params ***
-    // release (to upgrade to) - master or stable/ocata
+    // release (to upgrade to)
     // retries - number of times to rerun
-    // fake_results calls different method to return expected fails for testing
 
     String host_ip = get_deploy_node_ip()
     String upgrade_output = ""
 
-    //call upgrade, fake_results allows testing while environment not usable
     echo "Running upgrade"
-    if (fake_results) {
-        upgrade_output = fake_run_upgrade_return_results(release, host_ip)
-    } else {
-        upgrade_output = run_upgrade_return_results(release, host_ip)
-    }
+
+    // log upgrade start time
+    sh """
+        echo "Started: \$(date +%s)" > upgrade_time.txt
+        version_start=\$(ssh -o StrictHostKeyChecking=no root@${host_ip} \"cd /opt/openstack-ansible; git status | head -1\")
+        echo \${version_start} >> upgrade_time.txt
+    """
+
+    upgrade_output = run_upgrade_return_results(release, host_ip)
+
     //take upgrade_output, find out if it's got a failure in it
-    echo "Echoing Upgrade Results"
+    echo "Upgrade Results"
     echo "-----------------------"
     echo upgrade_output
     echo "-----------------------"
@@ -640,49 +586,26 @@ def bash_upgrade_openstack(release='master', retries=2, fake_results=false) {
         echo "Upgrade failed"
         for (int i = 0; i < retries; i++){
             echo "Rerunning upgrade, retry #" + (i + 1)
-            if (fake_results) {
-                upgrade_output = fake_run_upgrade_return_results(release, host_ip)
-            } else {
-                upgrade_output = run_upgrade_return_results(release, host_ip)
-            }
+            upgrade_output = run_upgrade_return_results(release, host_ip)
             failure_output = parse_upgrade_results_for_failure(upgrade_output)
             if (failure_output.length() == 0){
                 echo "Upgrade succeeded"
+                // log upgrade end time
+                sh """
+                    echo "Completed: \$(date +%s)" >> upgrade_time.txt
+                    version_end=\$(ssh -o StrictHostKeyChecking=no root@${host_ip} \"cd /opt/openstack-ansible; git status | head -1\")
+                    echo \${version_end} >> upgrade_time.txt
+                """
+                echo "Echoing Upgrade Results for retry #" + (i + 1)
+                echo "------------------------------------"
+                echo upgrade_output
+                echo "------------------------------------"
                 break
             } else if (i == (retries -1)){
                 echo "Upgrade failed, exceeded retries"
             }
         }
     }
-    echo "Echoing Upgrade Results"
-    echo "-----------------------"
-    echo upgrade_output
-    echo "-----------------------"
-}
-
-def fake_run_upgrade_return_results(release='master', host_ip="127.0.0.1"){
-    //fakes it
-    String upgrade_output = ""
-    String failure_output = ""
-
-    upgrade_output = sh returnStdout: true, script: """
-        ssh -o StrictHostKeyChecking=no root@${host_ip} '''
-        echo "******************** failure ********************"
-        echo "The upgrade script has encountered a failure."
-        echo 'Failed on task \"rabbitmq-install.yml -e 'rabbitmq_upgrade=true'\"'
-        echo "Re-run the run-upgrade.sh script, or"
-        echo "execute the remaining tasks manually:"
-        echo "openstack-ansible rabbitmq-install.yml -e 'rabbitmq_upgrade=true'"
-        echo "openstack-ansible etcd-install.yml"
-        echo "openstack-ansible utility-install.yml"
-        echo "openstack-ansible rsyslog-install.yml"
-        echo "openstack-ansible /opt/openstack-ansible/scripts/upgrade-utilities/playbooks/memcached-flush.yml"
-        echo "openstack-ansible setup-openstack.yml"
-        echo "******************** failure ********************"
-        bash -c "exit 2" || echo "Failed Upgrade"
-        '''
-    """
-    return upgrade_output
 }
 
 def clear_ssh_host_key(controller_name="controller01") {
@@ -691,12 +614,12 @@ def clear_ssh_host_key(controller_name="controller01") {
 
 def run_upgrade_return_results(release="master", host_ip="127.0.0.1"){
     String upgrade_output = ""
-    String failure_output = ""
 
     upgrade_output = sh returnStdout: true, script: """
         ssh -o StrictHostKeyChecking=no root@${host_ip} '''
         set -x
         cd /opt/openstack-ansible
+
         git checkout ${release}
         git pull
         #LATEST_TAG=\$(git describe --abbrev=0 --tags)
@@ -710,21 +633,23 @@ def run_upgrade_return_results(release="master", host_ip="127.0.0.1"){
 }
 
 def parse_upgrade_results_for_failure(upgrade_output = null){
-  // Looking for failed output such as:
-  // ******************** failure ********************
-  // The upgrade script has encountered a failure.
-  // Failed on task "rabbitmq-install.yml -e 'rabbitmq_upgrade=true'"
-  // Re-run the run-upgrade.sh script, or
-  // execute the remaining tasks manually:
-  // openstack-ansible rabbitmq-install.yml -e 'rabbitmq_upgrade=true'
-  // openstack-ansible etcd-install.yml
-  // openstack-ansible utility-install.yml
-  // openstack-ansible rsyslog-install.yml
-  // openstack-ansible /opt/openstack-ansible/scripts/upgrade-utilities/playbooks/memcached-flush.yml
-  // openstack-ansible setup-openstack.yml
-  // ******************** failure ********************
-  // * Caveat, this only grabs the first failure block and returns it (assumes all controllers will
-  // either fail the same way, or we're just going to act on any fail the same way)
+  /*
+  Looking for failed output such as:
+  ******************** failure ********************
+  The upgrade script has encountered a failure.
+  Failed on task "rabbitmq-install.yml -e 'rabbitmq_upgrade=true'"
+  Re-run the run-upgrade.sh script, or
+  execute the remaining tasks manually:
+  openstack-ansible rabbitmq-install.yml -e 'rabbitmq_upgrade=true'
+  openstack-ansible etcd-install.yml
+  openstack-ansible utility-install.yml
+  openstack-ansible rsyslog-install.yml
+  openstack-ansible /opt/openstack-ansible/scripts/upgrade-utilities/playbooks/memcached-flush.yml
+  openstack-ansible setup-openstack.yml
+  ******************** failure ********************
+  * Caveat, this only grabs the first failure block and returns it (assumes all controllers will
+  either fail the same way, or we're just going to act on any fail the same way)
+  */
   split_output = upgrade_output.split("\n")
   String failure_output = ""
   boolean failure_found = false
@@ -756,24 +681,25 @@ def parse_upgrade_results_for_failure(upgrade_output = null){
 
 }
 
-def aggregate_results(host_ip, elasticsearch_ip, tempest_dir=null, controller_name="controller01") {
-    String container_ip = get_controller_utility_container_ip(controller_name)
+def aggregate_results(host_ip, elasticsearch_ip, controller_name="controller01") {
+    // move tempest output
     try {
        sh """
            set -x
-           TEMPEST_DIR=${tempest_dir}
            scp -o StrictHostKeyChecking=no\
            -o ProxyCommand='ssh -W %h:%p root@${host_ip}'\
-           -r root@${container_ip}:\$TEMPEST_DIR/output .
+           -r root@${controller_name}:/root/tempest/output .
 
            scp -o StrictHostKeyChecking=no\
            -r output ubuntu@${elasticsearch_ip}:/home/ubuntu/
        """
-   } catch(err) {
+    } catch(err) {
        echo "Error moving output directory"
        echo err.message
-   }
-   try {
+    }
+
+    // move output from uptime tests
+    try {
       sh """
           scp -o StrictHostKeyChecking=no\
           -o ProxyCommand='ssh -W %h:%p root@${host_ip}'\
@@ -782,39 +708,36 @@ def aggregate_results(host_ip, elasticsearch_ip, tempest_dir=null, controller_na
           scp -o StrictHostKeyChecking=no\
           output/* ubuntu@${elasticsearch_ip}:/home/ubuntu/output/
       """
-  } catch(err) {
+    } catch(err) {
       echo "Error moving output directory"
       echo err.message
-  }
-   try {
+    }
+
+    // move upgrade time information
+    try {
+      sh """
+         scp -o StrictHostKeyChecking=no\
+         upgrade_time.txt ubuntu@${elasticsearch_ip}:/home/ubuntu/output/
+      """
+    } catch(err) {
+     echo "Error moving upgrade_time.txt"
+     echo err.message
+    }
+
+    // move tempest subunit information
+    try {
        sh """
            set -x
-           TEMPEST_DIR=${tempest_dir}
            scp -o StrictHostKeyChecking=no\
            -o ProxyCommand='ssh -W %h:%p root@${host_ip}'\
-           -r root@${container_ip}:\$TEMPEST_DIR/subunit .
+           -r root@${controller_name}:/root/tempest/subunit .
 
            scp -o StrictHostKeyChecking=no\
            -r subunit ubuntu@${elasticsearch_ip}:/home/ubuntu/
        """
-   } catch(err) {
+    } catch(err) {
        echo "No subunit directory found"
        echo err.message
-   }
-}
-
-
-
-def upgrade_openstack(release = 'master') {
-
-    try {
-        // Upgrade OSA to a specific release
-        echo "Running the following playbook: upgrade_osa, to upgrade to the following release: ${release}"
-        ansiblePlaybook extras: "-e openstack_release=${release}", inventory: 'hosts', playbook: 'upgrade_osa.yaml', sudoUser: null
-    } catch (err) {
-        echo "Retrying upgrade, failure on first attempt: " + err
-        // Retry Upgrade OSA to a specific release
-        ansiblePlaybook extras: "-e openstack_release=${release}", inventory: 'hosts', playbook: 'upgrade_osa.yaml', sudoUser: null
     }
 }
 

--- a/jenkins/bme_upgrade.pipeline
+++ b/jenkins/bme_upgrade.pipeline
@@ -2,7 +2,7 @@
 
 def osa, common, bme
 String workspace_dir
-String container_tempest_dir, deploy_node_ip, controller_utility_container_ip, elasticsearch_ip, elasticsearch_pkey
+String deploy_node_ip, elasticsearch_ip, elasticsearch_pkey
 
 // Jenkins must provide these variables as parameters or the build
 // will fail:
@@ -12,7 +12,7 @@ String container_tempest_dir, deploy_node_ip, controller_utility_container_ip, e
 
 // *******************************
 stage('Pre-Deployment -- Load Libs'){
-// *******************************
+    // *******************************
     node('bme-jenkins-slave-n01') {
         // Load the external functions using master since the git command
         // might not be available at the agent yet
@@ -44,16 +44,14 @@ stage('Pre-Deployment -- Configure Network on Jenkins Build Node'){
             """
         }
         deploy_node_ip = bme.get_deploy_node_ip()
-        controller_utility_container_ip = bme.get_controller_utility_container_ip(controller_name)
     }
 }
 
-node('elasticsearch'){
-    stage("Clean up any previous test run results"){
-      bme.cleanup_test_results()
+stage('Clean up previous run results'){
+    node('elasticsearch'){
+        bme.cleanup_test_results()
     }
 }
-
 
 node('bme-jenkins-slave-n01'){
     // env prep
@@ -68,117 +66,112 @@ node('bme-jenkins-slave-n01'){
     }
 }
 
-
-
 node('bme-jenkins-slave-n01'){
     stage('Install and Configure tempest'){
         bme.setup_ssh_pub_key()
         bme.install_tempest_tests(controller_name)
-        bme.configure_tempest(controller_name, '/opt/tempest_untagged')
-        container_tempest_dir = bme.get_tempest_dir(controller_name)
     }
     stage('Run Tempest Smoke Tests') {
-        bme.run_tempest_tests(controller_name, 'smoke', 'before_upgrade', elasticsearch_ip, '/opt/tempest_untagged')
+        bme.run_tempest_tests(controller_name, 'smoke', 'before_upgrade', elasticsearch_ip)
     }
 }
 
 stage('Pre-Upgrade Configuration'){
     node('bme-jenkins-slave-n01'){
-      try {    
-        bme.clear_ssh_host_key(controller_name)
+      try {
+          bme.clear_ssh_host_key(controller_name)
       } catch (err){
             sh "sleep 300"
-            echo "Error in step clear_ssh_host_ke"
+            echo "Error in step clear_ssh_host_key"
             echo err.message
       }
       try {
-        bme.transfer_tempest_configuration_to_controller(controller_name)
+          bme.transfer_tempest_configuration_to_controller(controller_name)
       } catch (err){
             sh "sleep 300"
             echo "Error in step transfer_tempest_configuration_to_controller"
             echo err.message
       }
       try {
-	bme.install_api_uptime_tests(controller_name, container_tempest_dir)
+	        bme.install_api_uptime_tests(controller_name)
       } catch (err){
             sh "sleep 300"
             echo "Error in step install_api_uptime_test"
             echo err.message
       }
-      try {  
-	bme.install_during_upgrade_tests(controller_name, container_tempest_dir)
+      try {
+	       bme.install_during_upgrade_tests(controller_name)
       } catch (err){
             sh "sleep 300"
             echo "Error in step install_during_upgrade_tests"
             echo err.message
       }
-      try {  
-	bme.install_persistent_resources_tests(controller_name, container_tempest_dir)
+      try {
+	       bme.install_persistent_resources_tests(controller_name)
       } catch (err){
             sh "sleep 300"
             echo "Error in step install_persistent_resources_tests"
             echo err.message
       }
-      try {  
-	bme.install_persistent_resources_tests_parse(controller_name, container_tempest_dir)
+      try {
+	       bme.install_persistent_resources_tests_parse(controller_name)
       } catch (err){
             sh "sleep 300"
             echo "Error in step install_persistent_resources_tests_parse"
             echo err.message
       }
       try {
-	  bme.install_rally(controller_name, container_tempest_dir)
+	       bme.install_rally(controller_name)
       } catch (err){
             sh "sleep 300"
             echo "Error in step install_rally"
             echo err.message
       }
       try {
-	  bme.prime_rally_benchmarks(controller_name, container_tempest_dir)
+	       bme.prime_rally_benchmarks(controller_name)
       } catch (err){
             sh "sleep 300"
             echo "Error in step prime_rally_benchmarks"
             echo err.message
       }
       try {
-	  bme.run_rally_benchmarks(controller_name, container_tempest_dir, 'before_upgrade')
+	       bme.run_rally_benchmarks(controller_name, 'before_upgrade')
       } catch (err){
             sh "sleep 300"
             echo "Error in step run_rally_benchmarks"
-            echo err.message 
+            echo err.message
       }
-      try {  
-	bme.run_persistent_resources_tests(controller_name, 'create', null, container_tempest_dir)
+      try {
+	       bme.run_persistent_resources_tests(controller_name, 'create', null)
       } catch (err){
             sh "sleep 300"
             echo "Error in step run_persistent_resources_tests"
             echo err.message
       }
-      try {  
-	bme.run_persistent_resources_tests(controller_name, 'verify', 'before_upgrade', container_tempest_dir)
+      try {
+	       bme.run_persistent_resources_tests(controller_name, 'verify', 'before_upgrade')
       } catch (err){
             sh "sleep 300"
             echo "Error in step run_persistent_resources_tests"
             echo err.message
       }
-
     }
 }
 
 
 node('bme-jenkins-slave-n01'){
     stage('Start Upgrade tests'){
-        bme.start_api_uptime_tests(controller_name, container_tempest_dir)
-        bme.start_during_upgrade_test(controller_name, container_tempest_dir)
-	bme.start_nova_during_upgrade_test(controller_name, container_tempest_dir)
+        bme.start_api_uptime_tests(controller_name)
+        bme.start_during_upgrade_test(controller_name)
+	bme.start_nova_during_upgrade_test(controller_name)
     }
     stage('Run Upgrade'){
 	      bme.bash_upgrade_openstack(to_release, 1, false)
     }
     stage('Stop Upgrade tests'){
         bme.clear_ssh_host_key(controller_name)
-        bme.stop_api_uptime_tests(controller_name, container_tempest_dir)
-        bme.stop_during_upgrade_test(controller_name, container_tempest_dir)
+        bme.stop_api_uptime_tests(controller_name)
+        bme.stop_during_upgrade_test(controller_name)
     }
 }
 
@@ -193,7 +186,7 @@ stage('Post-Upgrade -- Validate Deploy'){
           echo err.message
         }
         try {
-            bme.configure_tempest(controller_name, '/openstack/venvs/tempest-untagged')
+            bme.configure_tempest(controller_name)
         } catch (err){
             sh "sleep 300"
             echo "Error in step configure_tempest"
@@ -201,43 +194,43 @@ stage('Post-Upgrade -- Validate Deploy'){
         }
         try {
             sh "sleep 300"
-            bme.run_tempest_tests(controller_name, 'smoke', 'after_upgrade', elasticsearch_ip, '/openstack/venvs/tempest-untagged')
+            bme.run_tempest_tests(controller_name, 'smoke', 'after_upgrade', elasticsearch_ip)
         } catch (err){
             echo "Error in step run_tempest_tests"
             echo err.message
         }
         try {
-            bme.run_persistent_resources_tests(controller_name, 'verify', 'after_upgrade', '/openstack/venvs/tempest-untagged')
+            bme.run_persistent_resources_tests(controller_name, 'verify', 'after_upgrade')
         } catch (err){
             echo "Error in step run_persistent_resources_test"
             echo err.message
         }
         try {
-          bme.run_persistent_resources_tests(controller_name, 'clean', null, '/openstack/venvs/tempest-untagged')
+          bme.run_persistent_resources_tests(controller_name, 'clean', null)
         } catch (err){
           echo "Error in step run_persistent_resources_test"
           echo err.message
         }
         try {
-          bme.install_persistent_resources_tests_parse(controller_name, '/openstack/venvs/tempest-untagged')
+          bme.install_persistent_resources_tests_parse(controller_name)
         } catch (err){
           echo "Error in step install_persistent_resources_tests_parse"
           echo err.message
         }
         try {
-          bme.prime_rally_benchmarks(controller_name, '/openstack/venvs/tempest-untagged')
+          bme.prime_rally_benchmarks(controller_name)
         } catch (err){
           echo "Error in step prime_rally_benchmarks"
           echo err.message
         }
         try {
-          bme.run_rally_benchmarks(controller_name, '/openstack/venvs/tempest-untagged', 'after_upgrade')
+          bme.run_rally_benchmarks(controller_name, 'after_upgrade')
         } catch (err){
           echo "Error in step run_rally_benchmarks"
           echo err.message
         }
         try {
-            bme.parse_persistent_resources_tests(controller_name, '/opt/tempest_untagged')
+            bme.parse_persistent_resources_tests(controller_name)
         } catch (err){
             echo "Error in step parse_persistent_resources_tests"
             echo err.message
@@ -248,7 +241,7 @@ stage('Post-Upgrade -- Validate Deploy'){
 stage('Post-Upgrade -- Reporting'){
     node('bme-jenkins-slave-n01'){
       try {
-          bme.aggregate_results(deploy_node_ip, elasticsearch_ip, container_tempest_dir, controller_name)
+          bme.aggregate_results(deploy_node_ip, elasticsearch_ip, controller_name)
       } catch (err){
           echo "Error in step aggregate_results"
           echo err.message


### PR DESCRIPTION
to container, but to also install tempest master on controller.

This also combines previous configure_tempest to occur during installation,
copying generated tempest configuration to the controller node and updating
to use generated configuration values and template from github.

* Updates to run tests on controller node rather than utility container

* Adds file to record start and end of upgrade, as well as verisons

* Cleans up some formatting issues for consistency

* Removes fake_upgrade_results as it was only used for previous testing

* Removes duplicate reporting of upgrade output

* Removes unused method for using ansible to upgrade

* final removal of unused parameters, function calls.... until the missed ones are found while running